### PR TITLE
fix login/signup prompt

### DIFF
--- a/New Bank/NewBank/newbank/server/NewBank.java
+++ b/New Bank/NewBank/newbank/server/NewBank.java
@@ -124,8 +124,9 @@ public class NewBank {
 			catch (IOException e) {
 				e.printStackTrace();
 			}
+			return "SUCCESS";
 		}
-		return "SUCCESS";
+		return "FAIL";
 	}
 
 	// commands from the NewBank customer are processed in this method


### PR DESCRIPTION
There was a bug in the first prompt for LOGIN or SINGUP. The program was processing to the LOGIN stage with any command. This is fixed. Now it will only proceed to login stage if "LOGIN" is entered.